### PR TITLE
mm: use ELF file's target arch-specific page sizes when aligning

### DIFF
--- a/lib/patchelf/helper.rb
+++ b/lib/patchelf/helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'elftools/constants'
+
 module PatchELF
   # Helper methods for internal usage.
   module Helper
@@ -17,7 +19,8 @@ module PatchELF
     def page_size(e_machine = nil)
       # Different architectures have different minimum section alignments.
       case e_machine
-      when ELFTools::Constants::EM_SPARC,
+      when ELFTools::Constants::EM_ALPHA,
+           ELFTools::Constants::EM_IA_64,
            ELFTools::Constants::EM_MIPS,
            ELFTools::Constants::EM_PPC,
            ELFTools::Constants::EM_PPC64,
@@ -25,6 +28,9 @@ module PatchELF
            ELFTools::Constants::EM_TILEGX,
            ELFTools::Constants::EM_LOONGARCH
         0x10000
+      when ELFTools::Constants::EM_SPARC,
+           ELFTools::Constants::EM_SPARCV9
+        0x2000
       else
         0x1000
       end

--- a/lib/patchelf/mm.rb
+++ b/lib/patchelf/mm.rb
@@ -105,12 +105,19 @@ module PatchELF
       #=>
       # |  1      | |  2  |
       # |  1      |    |  2  |
-      idx = find_gap(check_sz: false) { |prv, nxt| PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail }
+      extension = PatchELF::Helper.alignup(@request_size, page_size)
+      idx = find_gap(check_sz: false) do |prv, nxt|
+        gap = PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail
+        # Forward growth moves the entire mapping back by the rounded extension.
+        next 0 if !writable?(prv) && gap < extension
+
+        gap
+      end
       return false if idx.nil?
 
       loads = load_segments
       @threshold = loads[idx].file_head
-      @extend_size = PatchELF::Helper.alignup(@request_size, page_size)
+      @extend_size = extension
       shift_attributes
       # prefer backward than forward
       return extend_backward?(loads[idx - 1]) if writable?(loads[idx - 1])

--- a/lib/patchelf/mm.rb
+++ b/lib/patchelf/mm.rb
@@ -105,12 +105,12 @@ module PatchELF
       #=>
       # |  1      | |  2  |
       # |  1      |    |  2  |
-      idx = find_gap(check_sz: false) { |prv, nxt| PatchELF::Helper.aligndown(nxt.mem_head) - prv.mem_tail }
+      idx = find_gap(check_sz: false) { |prv, nxt| PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail }
       return false if idx.nil?
 
       loads = load_segments
       @threshold = loads[idx].file_head
-      @extend_size = PatchELF::Helper.alignup(@request_size)
+      @extend_size = PatchELF::Helper.alignup(@request_size, page_size)
       shift_attributes
       # prefer backward than forward
       return extend_backward?(loads[idx - 1]) if writable?(loads[idx - 1])
@@ -160,8 +160,12 @@ module PatchELF
         next unless seg.header.p_offset >= threshold
 
         seg.header.p_offset += extend_size
-        # We have to change align of LOAD segment since ld.so checks it.
-        seg.header.p_align = Helper.page_size if seg.is_a?(ELFTools::Segments::LoadSegment)
+        # Preserve a valid alignment; ld.so requires LOAD addresses to be congruent.
+        next unless seg.is_a?(ELFTools::Segments::LoadSegment) &&
+                    seg.header.p_align.nonzero? &&
+                    ((seg.header.p_vaddr - seg.header.p_offset) % seg.header.p_align).nonzero?
+
+        seg.header.p_align = page_size
       end
 
       @elf.header.e_shoff += extend_size if @elf.header.e_shoff >= threshold
@@ -177,6 +181,10 @@ module PatchELF
         block.call(cur, seg.offset_to_vma(cur))
         cur += sz
       end
+    end
+
+    def page_size
+      Helper.page_size(@elf.header.e_machine)
     end
 
     def abnormal_elf(msg)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -20,4 +20,21 @@ describe PatchELF::Helper do
     expect(described_class.alignup(0x33, 0x20)).to be 0x40
     expect(described_class.alignup(0x10, 0x8)).to be 0x10
   end
+
+  it 'returns the target architecture page size' do
+    {
+      ELFTools::Constants::EM_ALPHA => 0x10000,
+      ELFTools::Constants::EM_IA_64 => 0x10000,
+      ELFTools::Constants::EM_MIPS => 0x10000,
+      ELFTools::Constants::EM_PPC => 0x10000,
+      ELFTools::Constants::EM_PPC64 => 0x10000,
+      ELFTools::Constants::EM_AARCH64 => 0x10000,
+      ELFTools::Constants::EM_TILEGX => 0x10000,
+      ELFTools::Constants::EM_LOONGARCH => 0x10000,
+      ELFTools::Constants::EM_SPARC => 0x2000,
+      ELFTools::Constants::EM_SPARCV9 => 0x2000
+    }.each do |e_machine, page_size|
+      expect(described_class.page_size(e_machine)).to eq page_size
+    end
+  end
 end

--- a/spec/mm_spec.rb
+++ b/spec/mm_spec.rb
@@ -24,7 +24,7 @@ describe PatchELF::MM do
     f
   end
 
-  def test_dispatch(request_size, loads, &block)
+  def test_dispatch(request_size, loads, e_machine: ELFTools::Constants::EM_X86_64, &block)
     elf = {}
     allow(elf).to receive(:segments_by_type).and_return loads
     obj = allow(elf).to receive(:each_segments)
@@ -32,6 +32,7 @@ describe PatchELF::MM do
     allow(elf).to receive(:each_sections) {} # do nothing
     ehdr = ELFTools::Structs::ELF_Ehdr.new(endian: :little)
     ehdr.elf_class = 64
+    ehdr.e_machine = e_machine
     allow(elf).to receive(:header).and_return ehdr
 
     mm = described_class.new(elf)
@@ -69,6 +70,50 @@ describe PatchELF::MM do
     it 'new_load_method' do
       loads = [make_load(0, 0xa2c, 0, 0xa2c, 'rx'), make_load(0xeb0, 0x158, 0x1eb0, 0x15c, 'rw')]
       expect { test_dispatch(0x2000, loads) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'architecture-specific page sizes' do
+    it 'mgap with AArch64 (64KB page size)' do
+      # AArch64 uses 64KB page size (0x10000)
+      # The memory gap must be aligned to 64KB
+      loads = [
+        make_load(0, 0x666, 0x10000, 0x666, 'rx'),
+        make_load(0x668, 8, 0x20000, 8, 'rw')
+      ]
+      called = 0
+      test_dispatch(0x100, loads, e_machine: ELFTools::Constants::EM_AARCH64) do |off, vaddr|
+        expect(off).to be 0x668
+        # vaddr should be aligned down to 64KB boundary
+        expect(vaddr).to be 0x10000
+        called += 1
+      end
+      expect(loads[1].file_head).to be 0x668
+      expect(called).to be 1
+    end
+
+    it 'preserves congruent PT_LOAD alignment after shifting' do
+      loads = [
+        make_load(0, 0x1000, 0x10000, 0x1000, 'rx'),
+        make_load(0x1800, 0x1000, 0x15800, 0x1000, 'rw')
+      ]
+      loads[1].header.p_align = 0x2000
+      test_dispatch(0x2000, loads)
+      expect(loads[1].header.p_align).to eq 0x2000
+      expect(loads[1].header.p_vaddr % loads[1].header.p_align)
+        .to eq(loads[1].header.p_offset % loads[1].header.p_align)
+    end
+
+    it 'repairs PT_LOAD alignment made incongruent by shifting' do
+      loads = [
+        make_load(0, 0x1000, 0x1000, 0x1000, 'rx'),
+        make_load(0x1800, 0x1000, 0x3800, 0x1000, 'rw')
+      ]
+      loads[1].header.p_align = 0x2000
+      test_dispatch(0x1000, loads)
+      expect(loads[1].header.p_align).to eq 0x1000
+      expect(loads[1].header.p_vaddr % loads[1].header.p_align)
+        .to eq(loads[1].header.p_offset % loads[1].header.p_align)
     end
   end
 

--- a/spec/mm_spec.rb
+++ b/spec/mm_spec.rb
@@ -56,11 +56,11 @@ describe PatchELF::MM do
     end
 
     it 'mgap' do
-      loads = [make_load(0, 0x666, 0x1000, 0x666, 'rx'), make_load(0x668, 8, 0x2668, 8, 'rw')]
+      loads = [make_load(0, 0x666, 0x1000, 0x666, 'rx'), make_load(0x668, 8, 0x3668, 8, 'rw')]
       called = 0
       test_dispatch(0x100, loads) do |off, vaddr|
         expect(off).to be 0x668
-        expect(vaddr).to be 0x1668
+        expect(vaddr).to be 0x2668
         called += 1
       end
       expect(loads[1].file_head).to be 0x668
@@ -75,21 +75,53 @@ describe PatchELF::MM do
 
   describe 'architecture-specific page sizes' do
     it 'mgap with AArch64 (64KB page size)' do
-      # AArch64 uses 64KB page size (0x10000)
-      # The memory gap must be aligned to 64KB
       loads = [
-        make_load(0, 0x666, 0x10000, 0x666, 'rx'),
-        make_load(0x668, 8, 0x20000, 8, 'rw')
+        make_load(0, 0xf800, 0x10000, 0xf800, 'rx'),
+        make_load(0x10000, 0x1000, 0x30000, 0x1000, 'rw')
       ]
+      loads.each { |seg| seg.header.p_align = 0x10000 }
       called = 0
-      test_dispatch(0x100, loads, e_machine: ELFTools::Constants::EM_AARCH64) do |off, vaddr|
-        expect(off).to be 0x668
-        # vaddr should be aligned down to 64KB boundary
-        expect(vaddr).to be 0x10000
+      test_dispatch(0x1000, loads, e_machine: ELFTools::Constants::EM_AARCH64) do |off, vaddr|
+        expect(off).to be 0x10000
+        expect(vaddr).to be 0x20000
         called += 1
       end
-      expect(loads[1].file_head).to be 0x668
+      expect(loads[1].file_head).to be 0x10000
+      expect(PatchELF::Helper.aligndown(loads[1].mem_head, 0x10000))
+        .to be >= PatchELF::Helper.alignup(loads[0].mem_tail, 0x10000)
       expect(called).to be 1
+    end
+
+    [0x20000, 0x22000].each do |vaddr|
+      it "rejects a rounded forward extension that overlaps a mapped page at #{vaddr.to_s(16)}" do
+        loads = [
+          make_load(0, 0x1800, 0x10000, 0x1800, 'rx'),
+          make_load(0x2000, 0x1000, vaddr, 0x1000, 'rw')
+        ]
+        loads.each { |seg| seg.header.p_align = 0x1000 }
+        headers = loads.map { |seg| seg.header.to_binary_s }
+        callback = double('callback')
+        expect(callback).not_to receive(:call)
+
+        expect do
+          test_dispatch(0x1000, loads, e_machine: ELFTools::Constants::EM_AARCH64) { |*args| callback.call(*args) }
+        end.to raise_error(NotImplementedError)
+        expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+      end
+    end
+
+    it 'allows backward growth when only the unrounded request fits' do
+      loads = [
+        make_load(0, 0x1800, 0x10000, 0x1800, 'rw'),
+        make_load(0x2000, 0x1000, 0x20000, 0x1000, 'r')
+      ]
+      loads.each { |seg| seg.header.p_align = 0x1000 }
+      test_dispatch(0x1000, loads, e_machine: ELFTools::Constants::EM_AARCH64) do |off, vaddr|
+        expect(off).to be 0x1800
+        expect(vaddr).to be 0x11800
+      end
+      expect(loads[0].mem_tail).to be 0x12800
+      expect(loads[1].file_head).to be 0x12000
     end
 
     it 'preserves congruent PT_LOAD alignment after shifting' do


### PR DESCRIPTION
- Add a helper function to obtain the applicable page size for the given ELF architecture
- Use the arch-specific page size when aligning in `mgap_method?` and `shift_attributes`
- Adjust gap check to use rounded request size (which matches the page-rounded extension size), rather than unrounded