### PR TITLE
mm: prevent BSS overlap during growth

### DIFF
--- a/lib/patchelf/mm.rb
+++ b/lib/patchelf/mm.rb
@@ -73,12 +73,12 @@ module PatchELF
     private
 
     def fgap_method?
-      idx = find_gap { |prv, nxt| nxt.file_head - prv.file_tail }
+      idx = find_gap { |prv, nxt| fgap_size(prv, nxt) }
       return false if idx.nil?
 
       loads = load_segments
       # prefer extend backwardly
-      return extend_backward?(loads[idx - 1]) if writable?(loads[idx - 1])
+      return extend_backward?(loads[idx - 1]) if backward_growth_possible?(loads[idx - 1], loads[idx])
 
       extend_forward?(loads[idx])
     end
@@ -106,13 +106,7 @@ module PatchELF
       # |  1      | |  2  |
       # |  1      |    |  2  |
       extension = PatchELF::Helper.alignup(@request_size, page_size)
-      idx = find_gap(check_sz: false) do |prv, nxt|
-        gap = PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail
-        # Forward growth moves the entire mapping back by the rounded extension.
-        next 0 if !writable?(prv) && gap < extension
-
-        gap
-      end
+      idx = find_gap(check_sz: false) { |prv, nxt| mgap_size(prv, nxt, extension) }
       return false if idx.nil?
 
       loads = load_segments
@@ -120,7 +114,8 @@ module PatchELF
       @extend_size = extension
       shift_attributes
       # prefer backward than forward
-      return extend_backward?(loads[idx - 1]) if writable?(loads[idx - 1])
+      return extend_backward?(loads[idx - 1]) if writable?(loads[idx - 1]) &&
+                                                 backward_growth_allowed?(loads[idx - 1])
 
       # NOTE: loads[idx].file_head has been changed in shift_attributes
       extend_forward?(loads[idx], @extend_size)
@@ -148,6 +143,37 @@ module PatchELF
 
     def writable?(seg)
       seg.readable? && seg.writable?
+    end
+
+    def backward_growth_allowed?(seg)
+      seg.header.p_memsz == seg.header.p_filesz
+    end
+
+    def backward_growth_possible?(prv, nxt)
+      writable?(prv) && backward_growth_allowed?(prv) &&
+        PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail >= @request_size
+    end
+
+    def fgap_size(prv, nxt)
+      file_gap = nxt.file_head - prv.file_tail
+      return file_gap if file_gap.negative?
+      return file_gap if backward_growth_possible?(prv, nxt)
+
+      # Forward growth moves the next mapping into the preceding page.
+      return 0 unless writable?(nxt) &&
+                      PatchELF::Helper.aligndown(nxt.mem_head - @request_size, page_size) >= prv.mem_tail
+
+      file_gap
+    end
+
+    def mgap_size(prv, nxt, extension)
+      gap = PatchELF::Helper.aligndown(nxt.mem_head, page_size) - prv.mem_tail
+      return gap if writable?(prv) && backward_growth_allowed?(prv)
+
+      # Forward growth moves the entire mapping back by the rounded extension.
+      return 0 unless writable?(nxt) && gap >= extension
+
+      gap
     end
 
     # For all attributes >= threshold, += offset

--- a/spec/mm_spec.rb
+++ b/spec/mm_spec.rb
@@ -150,6 +150,65 @@ describe PatchELF::MM do
   end
 
   describe 'extend backwardly' do
+    it 'uses forward growth when the previous LOAD has a BSS area' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x200, 'rw'),
+        make_load(0x200, 0x100, 0x3000, 0x100, 'rw')
+      ]
+      test_dispatch(0x20, loads) do |off, vaddr|
+        expect(off).to be 0x1e0
+        expect(vaddr).to be 0x2fe0
+      end
+      expect(loads[0].file_tail).to be 0x100
+      expect(loads[0].mem_tail).to be 0x1200
+      expect(loads[1].file_head).to be 0x1e0
+    end
+
+    it 'rejects a file gap when the virtual gap is too small' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x200, 'rw'),
+        make_load(0x200, 0x100, 0x1210, 0x100, 'rw')
+      ]
+      headers = loads.map { |seg| seg.header.to_binary_s }
+      callback = double('callback')
+      expect(callback).not_to receive(:call)
+
+      expect do
+        test_dispatch(0x20, loads) { |*args| callback.call(*args) }
+      end.to raise_error(NotImplementedError)
+      expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+    end
+
+    it 'rejects backward growth into the next LOAD aligned page' do
+      loads = [
+        make_load(0, 0x800, 0x1000, 0x800, 'rw'),
+        make_load(0x1200, 0x100, 0x2800, 0x100, 'r')
+      ]
+      headers = loads.map { |seg| seg.header.to_binary_s }
+      callback = double('callback')
+      expect(callback).not_to receive(:call)
+
+      expect do
+        test_dispatch(0x900, loads) { |*args| callback.call(*args) }
+      end.to raise_error(NotImplementedError)
+      expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+    end
+
+    it 'rejects forward growth that enters the previous LOAD page' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x1800, 'rw'),
+        make_load(0x200, 0x100, 0x3000, 0x100, 'rw')
+      ]
+      headers = loads.map { |seg| seg.header.to_binary_s }
+      callback = double('callback')
+      expect(callback).not_to receive(:call)
+
+      expect do
+        test_dispatch(0x100, loads) { |*args| callback.call(*args) }
+      end.to raise_error(NotImplementedError)
+      expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+    end
+
     it 'fgap' do
       loads = [make_load(0, 0x666, 0x1000, 0x666, 'rwx'), make_load(0x668, 8, 0x2668, 8, 'rw')]
       called = 0
@@ -180,6 +239,49 @@ describe PatchELF::MM do
       test_dispatch(0x200, loads)
       expect(loads[0].file_tail).to be 0xa66
       expect(loads[1].file_head).to be 0x1668
+    end
+
+    it 'does not use an m-gap when the previous LOAD has a BSS area' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x200, 'rw'),
+        make_load(0x200, 0x100, 0x3000, 0x100, 'r')
+      ]
+      headers = loads.map { |seg| seg.header.to_binary_s }
+      callback = double('callback')
+      expect(callback).not_to receive(:call)
+
+      expect do
+        test_dispatch(0x200, loads) { |*args| callback.call(*args) }
+      end.to raise_error(NotImplementedError)
+      expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+    end
+
+    it 'rejects an m-gap that fits the request but not the extension' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x200, 'rw'),
+        make_load(0x100, 0x100, 0x2e00, 0x100, 'rw')
+      ]
+      headers = loads.map { |seg| seg.header.to_binary_s }
+      callback = double('callback')
+      expect(callback).not_to receive(:call)
+
+      expect do
+        test_dispatch(0x800, loads) { |*args| callback.call(*args) }
+      end.to raise_error(NotImplementedError)
+      expect(loads.map { |seg| seg.header.to_binary_s }).to eq headers
+    end
+
+    it 'uses forward growth when the full m-gap extension fits' do
+      loads = [
+        make_load(0, 0x100, 0x1000, 0x200, 'rw'),
+        make_load(0x100, 0x100, 0x4000, 0x100, 'rw')
+      ]
+      test_dispatch(0x200, loads) do |off, vaddr|
+        expect(off).to be 0x100
+        expect(vaddr).to be 0x3000
+      end
+      expect(loads[0].mem_tail).to be 0x1200
+      expect(loads[1].mem_head).to be 0x3000
     end
   end
 


### PR DESCRIPTION
- Prevents segment growth from overwriting existing BSS data.
- Validates file and virtual-memory gaps before allocation.
- Accounts for page-aligned mappings during forward growth.
- Adds regression tests for BSS and page-overlap cases.